### PR TITLE
Add 6 new opensource model mappings (M3, Qwen 3.7, Step 3.7, MiMo v2.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ The proxy accepts full model IDs and these short aliases:
 | `qwen-3.6-plus`, `qwen3.6-plus`, `qwen3.6` | `Qwen/Qwen3.6-Plus` |
 | `step-3.5-flash`, `step3.5` | `stepfun/Step-3.5-Flash` |
 | `gemini-3.1-flash-lite`, `gemini-flash-lite` | `google/gemini-3.1-flash-lite` |
+| `minimax-m3`, `minimax3` | `MiniMaxAI/MiniMax-M3` |
+| `qwen-3.7-max-free`, `qwen3.7-max-free` | `Qwen/Qwen3.7-Max-Free` |
+| `qwen-3.7-max`, `qwen3.7-max` | `Qwen/Qwen3.7-Max` |
+| `step-3.7-flash`, `step3.7` | `stepfun/Step-3.7-Flash` |
+| `mimo-v2.5-pro`, `mimo-pro` | `xiaomi/mimo-v2.5-pro` |
+| `mimo-v2.5`, `mimo` | `xiaomi/mimo-v2.5` |
 
 Unknown model names are passed through unchanged.
 

--- a/internal/proxy/model.go
+++ b/internal/proxy/model.go
@@ -13,6 +13,8 @@ func MapModel(name string) string {
 		return "MiniMaxAI/MiniMax-M2.7"
 	case "minimax-m2.5", "minimax2.5", "minimax":
 		return "MiniMaxAI/MiniMax-M2.5"
+	case "minimax-m3", "minimax3":
+		return "MiniMaxAI/MiniMax-M3"
 	case "glm-5.1":
 		return "zai-org/GLM-5.1"
 	case "glm-5":

--- a/internal/proxy/model.go
+++ b/internal/proxy/model.go
@@ -13,7 +13,7 @@ func MapModel(name string) string {
 		return "MiniMaxAI/MiniMax-M2.7"
 	case "minimax-m2.5", "minimax2.5", "minimax":
 		return "MiniMaxAI/MiniMax-M2.5"
-	case "minimax-m3", "minimax3":
+	case "MiniMaxAI/MiniMax-M3", "minimax-m3", "minimax3":
 		return "MiniMaxAI/MiniMax-M3"
 	case "glm-5.1":
 		return "zai-org/GLM-5.1"
@@ -29,17 +29,17 @@ func MapModel(name string) string {
 		return "Qwen/Qwen3.6-Plus"
 	case "step-3.5-flash", "step3.5":
 		return "stepfun/Step-3.5-Flash"
-	case "step-3.7-flash", "step3.7":
+	case "step-3.7-flash", "step3.7", "stepfun/Step-3.7-Flash":
 		return "stepfun/Step-3.7-Flash"
 	case "gemini-3.1-flash-lite", "gemini-flash-lite":
 		return "google/gemini-3.1-flash-lite"
-	case "qwen-3.7-max-free", "qwen3.7-max-free":
+	case "qwen-3.7-max-free", "qwen3.7-max-free", "Qwen/Qwen3.7-Max-Free":
 		return "Qwen/Qwen3.7-Max-Free"
-	case "qwen-3.7-max", "qwen3.7-max":
+	case "qwen-3.7-max", "qwen3.7-max", "Qwen/Qwen3.7-Max":
 		return "Qwen/Qwen3.7-Max"
-	case "mimo-v2.5-pro":
+	case "mimo-v2.5-pro", "mimo-pro", "xiaomi/mimo-v2.5-pro":
 		return "xiaomi/mimo-v2.5-pro"
-	case "mimo-v2.5":
+	case "mimo-v2.5", "mimo", "xiaomi/mimo-v2.5":
 		return "xiaomi/mimo-v2.5"
 	default:
 		return name // pass through as-is

--- a/internal/proxy/model.go
+++ b/internal/proxy/model.go
@@ -27,8 +27,18 @@ func MapModel(name string) string {
 		return "Qwen/Qwen3.6-Plus"
 	case "step-3.5-flash", "step3.5":
 		return "stepfun/Step-3.5-Flash"
+	case "step-3.7-flash", "step3.7":
+		return "stepfun/Step-3.7-Flash"
 	case "gemini-3.1-flash-lite", "gemini-flash-lite":
 		return "google/gemini-3.1-flash-lite"
+	case "qwen-3.7-max-free", "qwen3.7-max-free":
+		return "Qwen/Qwen3.7-Max-Free"
+	case "qwen-3.7-max", "qwen3.7-max":
+		return "Qwen/Qwen3.7-Max"
+	case "mimo-v2.5-pro":
+		return "xiaomi/mimo-v2.5-pro"
+	case "mimo-v2.5":
+		return "xiaomi/mimo-v2.5"
 	default:
 		return name // pass through as-is
 	}

--- a/internal/proxy/model_test.go
+++ b/internal/proxy/model_test.go
@@ -1,0 +1,60 @@
+package proxy
+
+import "testing"
+
+func TestMapModel(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		// Existing short aliases
+		{"deepseek-v4-pro", "deepseek/deepseek-v4-pro"},
+		{"deepseek-v4", "deepseek/deepseek-v4-pro"},
+		{"DEEPSEEK-PRO", "deepseek/deepseek-v4-pro"},
+		{"deepseek-v4-flash", "deepseek/deepseek-v4-flash"},
+		{"deepseek-flash", "deepseek/deepseek-v4-flash"},
+		{"minimax-m2.7", "MiniMaxAI/MiniMax-M2.7"},
+		{"minimax-m2.5", "MiniMaxAI/MiniMax-M2.5"},
+		{"minimax", "MiniMaxAI/MiniMax-M2.5"},
+		{"glm-5.1", "zai-org/GLM-5.1"},
+		{"glm-5", "zai-org/GLM-5"},
+		{"kimi-k2.6", "moonshotai/Kimi-K2.6"},
+		{"kimi-k2.5", "moonshotai/Kimi-K2.5"},
+		{"qwen-3.6-max-preview", "Qwen/Qwen3.6-Max-Preview"},
+		{"qwen3.6", "Qwen/Qwen3.6-Plus"},
+		{"step-3.5-flash", "stepfun/Step-3.5-Flash"},
+		{"gemini-3.1-flash-lite", "google/gemini-3.1-flash-lite"},
+
+		// New short aliases
+		{"minimax-m3", "MiniMaxAI/MiniMax-M3"},
+		{"minimax3", "MiniMaxAI/MiniMax-M3"},
+		{"qwen-3.7-max-free", "Qwen/Qwen3.7-Max-Free"},
+		{"qwen3.7-max-free", "Qwen/Qwen3.7-Max-Free"},
+		{"qwen-3.7-max", "Qwen/Qwen3.7-Max"},
+		{"qwen3.7-max", "Qwen/Qwen3.7-Max"},
+		{"step-3.7-flash", "stepfun/Step-3.7-Flash"},
+		{"step3.7", "stepfun/Step-3.7-Flash"},
+		{"mimo-v2.5-pro", "xiaomi/mimo-v2.5-pro"},
+		{"mimo-pro", "xiaomi/mimo-v2.5-pro"},
+		{"mimo-v2.5", "xiaomi/mimo-v2.5"},
+		{"mimo", "xiaomi/mimo-v2.5"},
+
+		// New full IDs pass through
+		{"MiniMaxAI/MiniMax-M3", "MiniMaxAI/MiniMax-M3"},
+		{"Qwen/Qwen3.7-Max-Free", "Qwen/Qwen3.7-Max-Free"},
+		{"Qwen/Qwen3.7-Max", "Qwen/Qwen3.7-Max"},
+		{"stepfun/Step-3.7-Flash", "stepfun/Step-3.7-Flash"},
+		{"xiaomi/mimo-v2.5-pro", "xiaomi/mimo-v2.5-pro"},
+		{"xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5"},
+
+		// Unknown names pass through unchanged
+		{"some/unknown-model", "some/unknown-model"},
+		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := MapModel(c.in)
+		if got != c.want {
+			t.Errorf("MapModel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -688,6 +688,13 @@ func (p *Proxy) HandleModels(w http.ResponseWriter, r *http.Request) {
 			{ID: "Qwen/Qwen3.6-Plus", Object: "model", Created: 0, OwnedBy: "qwen"},
 			// StepFun
 			{ID: "stepfun/Step-3.5-Flash", Object: "model", Created: 0, OwnedBy: "stepfun"},
+			{ID: "stepfun/Step-3.7-Flash", Object: "model", Created: 0, OwnedBy: "stepfun"},
+			// Qwen (3.7 line)
+			{ID: "Qwen/Qwen3.7-Max-Free", Object: "model", Created: 0, OwnedBy: "qwen"},
+			{ID: "Qwen/Qwen3.7-Max", Object: "model", Created: 0, OwnedBy: "qwen"},
+			// Xiaomi MiMo
+			{ID: "xiaomi/mimo-v2.5-pro", Object: "model", Created: 0, OwnedBy: "xiaomi"},
+			{ID: "xiaomi/mimo-v2.5", Object: "model", Created: 0, OwnedBy: "xiaomi"},
 			// Google
 			{ID: "google/gemini-3.1-flash-lite", Object: "model", Created: 0, OwnedBy: "google"},
 		},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -680,6 +680,7 @@ func (p *Proxy) HandleModels(w http.ResponseWriter, r *http.Request) {
 			// MiniMaxAI
 			{ID: "MiniMaxAI/MiniMax-M2.7", Object: "model", Created: 0, OwnedBy: "minimaxai"},
 			{ID: "MiniMaxAI/MiniMax-M2.5", Object: "model", Created: 0, OwnedBy: "minimaxai"},
+			{ID: "MiniMaxAI/MiniMax-M3", Object: "model", Created: 0, OwnedBy: "minimaxai"},
 			// DeepSeek
 			{ID: "deepseek/deepseek-v4-pro", Object: "model", Created: 0, OwnedBy: "deepseek"},
 			{ID: "deepseek/deepseek-v4-flash", Object: "model", Created: 0, OwnedBy: "deepseek"},


### PR DESCRIPTION
Adds support for newer CommandCode opensource models and introduces unit tests for the model mapping function.

## New models
- `MiniMaxAI/MiniMax-M3` (alias: `minimax-m3`, `minimax3`)
- `Qwen/Qwen3.7-Max-Free` (alias: `qwen-3.7-max-free`, `qwen3.7-max-free`)
- `Qwen/Qwen3.7-Max` (alias: `qwen-3.7-max`, `qwen3.7-max`)
- `stepfun/Step-3.7-Flash` (alias: `step-3.7-flash`, `step3.7`)
- `xiaomi/mimo-v2.5-pro` (alias: `mimo-v2.5-pro`, `mimo-pro`)
- `xiaomi/mimo-v2.5` (alias: `mimo-v2.5`, `mimo`)

All new entries are also accepted via their full IDs (pass-through), matching the convention used for the existing models.

## Changes
- `internal/proxy/model.go` — new switch cases following the existing alias pattern
- `internal/proxy/proxy.go` — `HandleModels` lists the new full IDs
- `internal/proxy/model_test.go` — new unit tests covering all 18 model mappings (the package previously had no tests)
- `README.md` — alias table updated

## Verification
- `go test ./...` — PASS
- `go vet ./...` — clean
- All 18 models (12 existing + 6 new) return HTTP 200 from `/v1/chat/completions` end-to-end against the live CommandCode API.