### PR TITLE
Add context_length metadata and reasoning effort passthrough

### DIFF
--- a/internal/api/commandcode.go
+++ b/internal/api/commandcode.go
@@ -33,6 +33,7 @@ type CCChatParams struct {
 	MaxTokens   int         `json:"max_tokens"`
 	Temperature float64     `json:"temperature"`
 	Stream      bool        `json:"stream"`
+	Reasoning   string      `json:"reasoning,omitempty"`
 }
 
 type CCConfig struct {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -58,7 +58,16 @@ type OpenAIChatRequest struct {
 	PresencePenalty     *float64        `json:"presence_penalty,omitempty"`
 	FrequencyPenalty    *float64        `json:"frequency_penalty,omitempty"`
 	User                string          `json:"user,omitempty"`
+	Reasoning           *ReasoningEffort `json:"reasoning,omitempty"`
 }
+
+type ReasoningEffort string
+
+const (
+	ReasoningEffortLow    ReasoningEffort = "low"
+	ReasoningEffortMedium ReasoningEffort = "medium"
+	ReasoningEffortHigh   ReasoningEffort = "high"
+)
 
 type OpenAIResponsesRequest struct {
 	Model               string   `json:"model"`
@@ -131,10 +140,11 @@ type OpenAIError struct {
 }
 
 type OpenAIModel struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	Created int64  `json:"created"`
-	OwnedBy string `json:"owned_by"`
+	ID            string `json:"id"`
+	Object        string `json:"object"`
+	Created       int64  `json:"created"`
+	OwnedBy       string `json:"owned_by"`
+	ContextLength int    `json:"context_length,omitempty"`
 }
 
 type OpenAIModelList struct {

--- a/internal/proxy/model.go
+++ b/internal/proxy/model.go
@@ -13,6 +13,12 @@ func MapModel(name string) string {
 		return "MiniMaxAI/MiniMax-M2.7"
 	case "minimax-m2.5", "minimax2.5", "minimax":
 		return "MiniMaxAI/MiniMax-M2.5"
+	case "minimax-m3", "minimax3":
+		return "MiniMaxAI/MiniMax-M3"
+	case "minimax-m3-promo", "minimax3-promo":
+		return "MiniMaxAI/MiniMax-M3-Promo"
+	case "glm-5.2", "glm-52":
+		return "zai-org/GLM-5.2"
 	case "glm-5.1":
 		return "zai-org/GLM-5.1"
 	case "glm-5":
@@ -21,14 +27,52 @@ func MapModel(name string) string {
 		return "moonshotai/Kimi-K2.6"
 	case "kimi-k2.5", "kimi2.5":
 		return "moonshotai/Kimi-K2.5"
+	case "kimi-k2.7-code", "kimi2.7-code":
+		return "moonshotai/Kimi-K2.7-Code"
+	case "kimi-k2.7-code-highspeed", "kimi2.7-code-highspeed":
+		return "moonshotai/Kimi-K2.7-Code-Highspeed"
 	case "qwen-3.6-max-preview", "qwen3.6-max":
 		return "Qwen/Qwen3.6-Max-Preview"
 	case "qwen-3.6-plus", "qwen3.6-plus", "qwen3.6":
 		return "Qwen/Qwen3.6-Plus"
+	case "qwen-3.7-max", "qwen3.7-max":
+		return "Qwen/Qwen3.7-Max"
+	case "qwen-3.7-plus", "qwen3.7-plus", "qwen3.7":
+		return "Qwen/Qwen3.7-Plus"
 	case "step-3.5-flash", "step3.5":
 		return "stepfun/Step-3.5-Flash"
+	case "step-3.7-flash", "step3.7":
+		return "stepfun/Step-3.7-Flash"
+	case "mimo-v2.5-pro", "mimo2.5-pro":
+		return "xiaomi/mimo-v2.5-pro"
+	case "mimo-v2.5", "mimo2.5", "mimo":
+		return "xiaomi/mimo-v2.5"
+	case "nemotron-3-ultra", "nemotron":
+		return "nvidia/nemotron-3-ultra-550b-a55b"
+	case "claude-sonnet-4-6", "sonnet-4-6", "sonnet":
+		return "claude-sonnet-4-6"
+	case "claude-fable-5", "fable-5", "fable":
+		return "claude-fable-5"
+	case "claude-opus-4-8", "opus-4-8", "opus":
+		return "claude-opus-4-8"
+	case "claude-opus-4-7", "opus-4-7":
+		return "claude-opus-4-7"
+	case "claude-opus-4-6", "opus-4-6":
+		return "claude-opus-4-6"
+	case "claude-haiku-4-5", "haiku-4-5", "haiku":
+		return "claude-haiku-4-5"
+	case "gpt-5.5":
+		return "gpt-5.5"
+	case "gpt-5.4":
+		return "gpt-5.4"
+	case "gpt-5.3-codex", "codex":
+		return "gpt-5.3-codex"
+	case "gpt-5.4-mini", "gpt-mini":
+		return "gpt-5.4-mini"
 	case "gemini-3.1-flash-lite", "gemini-flash-lite":
 		return "google/gemini-3.1-flash-lite"
+	case "gemini-3.5-flash", "gemini-flash":
+		return "google/gemini-3.5-flash"
 	default:
 		return name // pass through as-is
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -95,6 +95,12 @@ func (p *Proxy) BuildRequest(openAIReq api.OpenAIChatRequest) (api.CCRequestBody
 
 	tools := ConvertTools(openAIReq.Tools)
 
+	// Map reasoning effort
+	var reasoning string
+	if openAIReq.Reasoning != nil {
+		reasoning = string(*openAIReq.Reasoning)
+	}
+
 	ccBody := api.CCRequestBody{
 		Config: api.CCConfig{
 			WorkingDir:    ".",
@@ -118,6 +124,7 @@ func (p *Proxy) BuildRequest(openAIReq api.OpenAIChatRequest) (api.CCRequestBody
 			MaxTokens:   maxTokens,
 			Temperature: temperature,
 			Stream:      true,
+			Reasoning:   reasoning,
 		},
 		ThreadID: uuid.New().String(),
 	}
@@ -672,24 +679,50 @@ func (p *Proxy) HandleModels(w http.ResponseWriter, r *http.Request) {
 		Object: "list",
 		Data: []api.OpenAIModel{
 			// MoonshotAI
-			{ID: "moonshotai/Kimi-K2.6", Object: "model", Created: 0, OwnedBy: "moonshotai"},
-			{ID: "moonshotai/Kimi-K2.5", Object: "model", Created: 0, OwnedBy: "moonshotai"},
+			{ID: "moonshotai/Kimi-K2.7-Code", Object: "model", Created: 0, OwnedBy: "moonshotai", ContextLength: 262144},
+			{ID: "moonshotai/Kimi-K2.7-Code-Highspeed", Object: "model", Created: 0, OwnedBy: "moonshotai", ContextLength: 262144},
+			{ID: "moonshotai/Kimi-K2.6", Object: "model", Created: 0, OwnedBy: "moonshotai", ContextLength: 262144},
+			{ID: "moonshotai/Kimi-K2.5", Object: "model", Created: 0, OwnedBy: "moonshotai", ContextLength: 262144},
 			// ZhipuAI
-			{ID: "zai-org/GLM-5.1", Object: "model", Created: 0, OwnedBy: "zhipuai"},
-			{ID: "zai-org/GLM-5", Object: "model", Created: 0, OwnedBy: "zhipuai"},
+			{ID: "zai-org/GLM-5.2", Object: "model", Created: 0, OwnedBy: "zhipuai", ContextLength: 1048576},
+			{ID: "zai-org/GLM-5.1", Object: "model", Created: 0, OwnedBy: "zhipuai", ContextLength: 202752},
+			{ID: "zai-org/GLM-5", Object: "model", Created: 0, OwnedBy: "zhipuai", ContextLength: 202752},
 			// MiniMaxAI
-			{ID: "MiniMaxAI/MiniMax-M2.7", Object: "model", Created: 0, OwnedBy: "minimaxai"},
-			{ID: "MiniMaxAI/MiniMax-M2.5", Object: "model", Created: 0, OwnedBy: "minimaxai"},
+			{ID: "MiniMaxAI/MiniMax-M3", Object: "model", Created: 0, OwnedBy: "minimaxai", ContextLength: 1000000},
+			{ID: "MiniMaxAI/MiniMax-M3-Promo", Object: "model", Created: 0, OwnedBy: "minimaxai", ContextLength: 1000000},
+			{ID: "MiniMaxAI/MiniMax-M2.7", Object: "model", Created: 0, OwnedBy: "minimaxai", ContextLength: 204800},
+			{ID: "MiniMaxAI/MiniMax-M2.5", Object: "model", Created: 0, OwnedBy: "minimaxai", ContextLength: 204800},
 			// DeepSeek
-			{ID: "deepseek/deepseek-v4-pro", Object: "model", Created: 0, OwnedBy: "deepseek"},
-			{ID: "deepseek/deepseek-v4-flash", Object: "model", Created: 0, OwnedBy: "deepseek"},
+			{ID: "deepseek/deepseek-v4-pro", Object: "model", Created: 0, OwnedBy: "deepseek", ContextLength: 1000000},
+			{ID: "deepseek/deepseek-v4-flash", Object: "model", Created: 0, OwnedBy: "deepseek", ContextLength: 1000000},
 			// Qwen
-			{ID: "Qwen/Qwen3.6-Max-Preview", Object: "model", Created: 0, OwnedBy: "qwen"},
-			{ID: "Qwen/Qwen3.6-Plus", Object: "model", Created: 0, OwnedBy: "qwen"},
+			{ID: "Qwen/Qwen3.6-Max-Preview", Object: "model", Created: 0, OwnedBy: "qwen", ContextLength: 1048576},
+			{ID: "Qwen/Qwen3.6-Plus", Object: "model", Created: 0, OwnedBy: "qwen", ContextLength: 1048576},
+			{ID: "Qwen/Qwen3.7-Max", Object: "model", Created: 0, OwnedBy: "qwen", ContextLength: 1048576},
+			{ID: "Qwen/Qwen3.7-Plus", Object: "model", Created: 0, OwnedBy: "qwen", ContextLength: 1048576},
 			// StepFun
-			{ID: "stepfun/Step-3.5-Flash", Object: "model", Created: 0, OwnedBy: "stepfun"},
+			{ID: "stepfun/Step-3.7-Flash", Object: "model", Created: 0, OwnedBy: "stepfun", ContextLength: 262144},
+			{ID: "stepfun/Step-3.5-Flash", Object: "model", Created: 0, OwnedBy: "stepfun", ContextLength: 262144},
+			// Xiaomi
+			{ID: "xiaomi/mimo-v2.5-pro", Object: "model", Created: 0, OwnedBy: "xiaomi", ContextLength: 1048576},
+			{ID: "xiaomi/mimo-v2.5", Object: "model", Created: 0, OwnedBy: "xiaomi", ContextLength: 1048576},
+			// NVIDIA
+			{ID: "nvidia/nemotron-3-ultra-550b-a55b", Object: "model", Created: 0, OwnedBy: "nvidia", ContextLength: 131072},
+			// Anthropic
+			{ID: "claude-sonnet-4-6", Object: "model", Created: 0, OwnedBy: "anthropic", ContextLength: 1000000},
+			{ID: "claude-fable-5", Object: "model", Created: 0, OwnedBy: "anthropic", ContextLength: 1000000},
+			{ID: "claude-opus-4-8", Object: "model", Created: 0, OwnedBy: "anthropic", ContextLength: 1000000},
+			{ID: "claude-opus-4-7", Object: "model", Created: 0, OwnedBy: "anthropic", ContextLength: 1000000},
+			{ID: "claude-opus-4-6", Object: "model", Created: 0, OwnedBy: "anthropic", ContextLength: 200000},
+			{ID: "claude-haiku-4-5", Object: "model", Created: 0, OwnedBy: "anthropic", ContextLength: 200000},
+			// OpenAI
+			{ID: "gpt-5.5", Object: "model", Created: 0, OwnedBy: "openai", ContextLength: 1050000},
+			{ID: "gpt-5.4", Object: "model", Created: 0, OwnedBy: "openai", ContextLength: 1050000},
+			{ID: "gpt-5.3-codex", Object: "model", Created: 0, OwnedBy: "openai", ContextLength: 400000},
+			{ID: "gpt-5.4-mini", Object: "model", Created: 0, OwnedBy: "openai", ContextLength: 400000},
 			// Google
-			{ID: "google/gemini-3.1-flash-lite", Object: "model", Created: 0, OwnedBy: "google"},
+			{ID: "google/gemini-3.5-flash", Object: "model", Created: 0, OwnedBy: "google", ContextLength: 1048576},
+			{ID: "google/gemini-3.1-flash-lite", Object: "model", Created: 0, OwnedBy: "google", ContextLength: 1048576},
 		},
 	}
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- Add context_length to OpenAIModel struct so Hermes can detect context windows and trigger compression at 50%
- Add reasoning effort passthrough (low/medium/high) to OpenAIChatRequest and CCChatParams
- Expand HandleModels from 12 to 33 Command Code models with accurate context windows
- Add short aliases (sonnet, opus, haiku, etc.) to MapModel
- Add missing models: GLM-5.2, claude-opus-4-6, MiniMax-M3-Promo

This enables Hermes to use the proxy with proper context awareness and reasoning control.